### PR TITLE
Add further styling to resolve bordering issues

### DIFF
--- a/HighlightedItems.cs
+++ b/HighlightedItems.cs
@@ -224,7 +224,14 @@ public class HighlightedItems : BaseSettingsPlugin<Settings>
                 if (isCustomFilter)
                 {
                     var rect = item.GetClientRectCache;
-                    Graphics.DrawFrame(rect.TopLeft.ToVector2Num(), rect.BottomRight.ToVector2Num(), Settings.CustomFilterFrameColor, Settings.CustomFilterFrameThickness);
+                    var deflateFactor = Settings.CustomFilterBorderDeflation / 200.0;
+                    var deflateWidth = (int)(rect.Width * deflateFactor + Settings.CustomFilterFrameThickness / 2);
+                    var deflateHeight = (int)(rect.Height * deflateFactor + Settings.CustomFilterFrameThickness / 2);
+                    rect.Inflate(-deflateWidth, -deflateHeight);
+
+                    var topLeft = rect.TopLeft.ToVector2Num();
+                    var bottomRight = rect.BottomRight.ToVector2Num();
+                    Graphics.DrawFrame(topLeft, bottomRight, Settings.CustomFilterFrameColor, Settings.CustomFilterBorderRounding, Settings.CustomFilterFrameThickness, 0);
                 }
             }
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -31,6 +31,8 @@ public class Settings : ISettings
     public ToggleNode UsePopupForFilterSelector { get; set; } = new(false);
     public RangeNode<int> CustomFilterFrameThickness { get; set; } = new(2, 1, 20);
     public ColorNode CustomFilterFrameColor { get; set; } = new(Color.Violet);
+    public RangeNode<float> CustomFilterBorderRounding { get; set; } = new(0, 0, 25);
+    public RangeNode<int> CustomFilterBorderDeflation { get; set; } = new(8, 0, 100);
 
     public RangeNode<int> ExtraDelay { get; set; } = new(20, 0, 100);
 


### PR DESCRIPTION
and interferes with other visuals that utilize the same draw method. The deflation reason is a 3x3 grid; the central item becomes visually indistinguishable when highlighted.